### PR TITLE
Cargo.toml: add dependency version

### DIFF
--- a/udev/Cargo.toml
+++ b/udev/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 keywords = ["udev"]
 
 [dependencies]
-basic-udev = { path = "../basic-udev" }
+basic-udev = { version = "0.1", path = "../basic-udev" }


### PR DESCRIPTION
This is needed when uploading those modules to a crate registry.